### PR TITLE
Add retry policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ func main() {
 	client := avoca.NewClient(
 		avoca.WithHTTPClient(
 			&http.Client{
+				// Timeout the HTTP connection after 200 ms.
 				Timeout: 200 * time.Millisecond,
 			},
 		),
+		// Perform maximum 10 attempts with an exponential backoff.
 		avoca.WithRetrier(
 			retry.New(
 				retry.WithMaxAttempts(10),
@@ -51,6 +53,7 @@ func main() {
 				),
 			),
 		),
+		// Only retry when the status code is >= 500
 		avoca.WithRetryPolicy(
 			func(statusCode int) bool {
 				return statusCode >= http.StatusInternalServerError

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ func main() {
 				),
 			),
 		),
+		avoca.WithRetryPolicy(
+			func(statusCode int) bool {
+				return statusCode >= http.StatusInternalServerError
+			},
+		),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/client.go
+++ b/client.go
@@ -45,13 +45,13 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 			return err
 		}
 		if c.retryPolicy(res.StatusCode) {
-			// Return a statusError to try again
-			return statusError
+			// Return a errStatus to try again
+			return errStatus
 		}
 		// The request went fine, no need to retry
 		return nil
 	})
-	if err != nil && !errors.Is(err, statusError) {
+	if err != nil && !errors.Is(err, errStatus) {
 		return nil, err
 	}
 	return res, nil

--- a/client.go
+++ b/client.go
@@ -9,9 +9,14 @@ import (
 )
 
 // Client composes a Doer and a Retrier.
+// By default, the client uses:
+//     * a http.Client with a timeout set to 60 * time.Second
+//     * a retrier that does not retry
+//     * a retry policy that return false for all HTTP codes
 type Client struct {
-	client  Doer
-	retrier Retrier
+	client      Doer
+	retrier     Retrier
+	retryPolicy RetryPolicy
 }
 
 // Doer interface that match the standard HTTP client `http.Do` interface.
@@ -24,6 +29,10 @@ type Retrier interface {
 	Do(context.Context, func(context.Context) error) error
 }
 
+// RetryPolicy describes the retry policy based on HTTP codes.
+// It should return true for retryable HTTP code and false otherwise.
+type RetryPolicy func(statusCode int) bool
+
 // Do makes an HTTP request with the native `http.Do` interface.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	var (
@@ -32,6 +41,12 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	)
 	if err := c.retrier.Do(req.Context(), func(context.Context) error {
 		res, err = c.client.Do(req) // nolint
+		if err != nil {
+			return err
+		}
+		if c.retryPolicy(res.StatusCode) {
+			return fmt.Errorf("received status %d", res.StatusCode) // nolint
+		}
 		return err
 	}); err != nil {
 		return nil, err
@@ -116,7 +131,12 @@ func WithRetrier(retrier Retrier) Option {
 	}
 }
 
-const defaultHTTPTimeout = 60 * time.Second
+// WithRetryPolicy sets the retry policy.
+func WithRetryPolicy(retryPolicy RetryPolicy) Option {
+	return func(c *Client) {
+		c.retryPolicy = retryPolicy
+	}
+}
 
 // NewClient returns a new instance of the Client.
 func NewClient(opts ...Option) *Client {
@@ -124,7 +144,8 @@ func NewClient(opts ...Option) *Client {
 		client: &http.Client{
 			Timeout: defaultHTTPTimeout,
 		},
-		retrier: &noRetry{},
+		retrier:     &noRetry{},
+		retryPolicy: defaultRetryPolicy,
 	}
 	for _, opt := range opts {
 		opt(&client)
@@ -132,8 +153,14 @@ func NewClient(opts ...Option) *Client {
 	return &client
 }
 
+const defaultHTTPTimeout = 60 * time.Second
+
 type noRetry struct{}
 
 func (r *noRetry) Do(ctx context.Context, fn func(context.Context) error) error {
 	return fn(ctx)
+}
+
+func defaultRetryPolicy(statusCode int) bool {
+	return false
 }

--- a/client_test.go
+++ b/client_test.go
@@ -243,7 +243,7 @@ func TestClientSpecificMethodHardFailure(t *testing.T) {
 	}
 }
 
-func TestClientSpecificMethodStatusFailure(t *testing.T) {
+func TestClientSpecificMethodStatusFailure(t *testing.T) { // nolint
 	hardFailures := 0
 	beforeStatusOK := 3
 	internalClient := failingHTTPClient(hardFailures, beforeStatusOK)

--- a/client_test.go
+++ b/client_test.go
@@ -16,16 +16,16 @@ type mockRetrier struct {
 	maxAttempts int
 }
 
+// nolint:gochecknoglobals
 var (
 	errFailRequest    = errors.New("fail this request")
-	dummyRequestBody  = `{ "id": "me" }`       // nolint
-	dummyResponseBody = `{ "response": "ok" }` // nolint
-	dummyHeader       = http.Header{           // nolint
+	dummyURL          = `whatever`
+	dummyRequestBody  = `{ "id": "me" }`
+	dummyResponseBody = `{ "response": "whatever" }`
+	dummyHeader       = http.Header{
 		"content-type": {"application/json"},
 	}
 )
-
-const dummyURL = "whatever"
 
 func (r *mockRetrier) Do(ctx context.Context, fn func(context.Context) error) error {
 	var err error
@@ -53,12 +53,12 @@ func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		c.count++
 		return &http.Response{
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(strings.NewReader(`{ "response": "not ok" }`)),
+			Body:       ioutil.NopCloser(strings.NewReader(dummyResponseBody)),
 		}, nil
 	}
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(`{ "response": "ok" }`)),
+		Body:       ioutil.NopCloser(strings.NewReader(dummyResponseBody)),
 	}, nil
 }
 
@@ -90,7 +90,7 @@ func TestClientDoSuccess(t *testing.T) {
 		}),
 	)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "whatever", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, dummyURL, nil)
 	require.NoError(t, err)
 
 	res, err := c.Do(req)
@@ -109,7 +109,7 @@ func TestClientDoFailure(t *testing.T) {
 		),
 	)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "whatever", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, dummyURL, nil)
 	require.NoError(t, err)
 
 	res, err := c.Do(req) // nolint
@@ -381,7 +381,7 @@ func (c *mockHTTPClientChecker) Do(req *http.Request) (*http.Response, error) {
 
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(`{ "response": "ok" }`)),
+		Body:       ioutil.NopCloser(strings.NewReader(dummyResponseBody)),
 	}, nil
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,21 @@
+package avoca
+
+import (
+	"errors"
+	"fmt"
+)
+
+// RequestCreationError is used to signal the request creation failed.
+type RequestCreationError struct {
+	Err error
+}
+
+// Error returns the error message.
+func (e *RequestCreationError) Error() string {
+	return fmt.Errorf("request creation failed: %w", e.Err).Error()
+}
+
+// statusError is only used to be able to differentiate between
+// an actual error from the underlying HTTP client and an
+// error that must be returned for retryable HTTP codes.
+var statusError = errors.New("status error") // nolint

--- a/errors.go
+++ b/errors.go
@@ -15,7 +15,7 @@ func (e *RequestCreationError) Error() string {
 	return fmt.Errorf("request creation failed: %w", e.Err).Error()
 }
 
-// statusError is only used to be able to differentiate between
+// errStatus is only used to be able to differentiate between
 // an actual error from the underlying HTTP client and an
 // error that must be returned for retryable HTTP codes.
-var statusError = errors.New("status error") // nolint
+var errStatus = errors.New("status error")

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,15 @@
+package avoca
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestCreationError(t *testing.T) {
+	err := RequestCreationError{
+		errors.New("an error message"), // nolint
+	}
+	assert.Equal(t, "request creation failed: an error message", err.Error())
+}


### PR DESCRIPTION
The goal of this change is to allow the user to explicit for which HTTP code the retry should occur.