### PR TITLE
Fix consumption of request body

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -8,6 +8,6 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.0.0
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.31

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2.1.2
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check out code into the Go module directory

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,5 +9,6 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
+        - goerr113
         - gomnd
         - testpackage

--- a/client_test.go
+++ b/client_test.go
@@ -118,7 +118,48 @@ func TestClientDoSuccess(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 }
 
-func TestClientSpecificMethodSuccess(t *testing.T) { // nolint: funlen
+func allMethodsTestCases(ctx context.Context, c *Client) []struct {
+	method string
+	fn     func() (*http.Response, error)
+} {
+	return []struct {
+		method string
+		fn     func() (*http.Response, error)
+	}{
+		{
+			http.MethodGet,
+			func() (*http.Response, error) {
+				return c.Get(ctx, dummyURL, dummyHeader)
+			},
+		},
+		{
+			http.MethodPost,
+			func() (*http.Response, error) {
+				return c.Post(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
+			},
+		},
+		{
+			http.MethodPut,
+			func() (*http.Response, error) {
+				return c.Put(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
+			},
+		},
+		{
+			http.MethodPatch,
+			func() (*http.Response, error) {
+				return c.Patch(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
+			},
+		},
+		{
+			http.MethodDelete,
+			func() (*http.Response, error) {
+				return c.Delete(ctx, dummyURL, dummyHeader)
+			},
+		},
+	}
+}
+
+func TestClientSpecificMethodSuccess(t *testing.T) {
 	hardFailures := 3
 	beforeStatusOK := hardFailures + 1
 	internalClient := newMockHTTPClient(t, hardFailures, beforeStatusOK)
@@ -135,44 +176,7 @@ func TestClientSpecificMethodSuccess(t *testing.T) { // nolint: funlen
 		}),
 	)
 
-	ctx := context.Background()
-
-	testCases := []struct {
-		method string
-		fn     func() (*http.Response, error)
-	}{
-		// {
-		// 	http.MethodGet,
-		// 	func() (*http.Response, error) {
-		// 		return c.Get(ctx, dummyURL, dummyHeader)
-		// 	},
-		// },
-		{
-			http.MethodPost,
-			func() (*http.Response, error) {
-				return c.Post(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		// {
-		// 	http.MethodPut,
-		// 	func() (*http.Response, error) {
-		// 		return c.Put(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-		// 	},
-		// },
-		// {
-		// 	http.MethodPatch,
-		// 	func() (*http.Response, error) {
-		// 		return c.Patch(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-		// 	},
-		// },
-		// {
-		// 	http.MethodDelete,
-		// 	func() (*http.Response, error) {
-		// 		return c.Delete(ctx, dummyURL, dummyHeader)
-		// 	},
-		// },
-	}
-	for _, tc := range testCases {
+	for _, tc := range allMethodsTestCases(context.Background(), c) { // nolint
 		tc := tc
 		t.Run(tc.method, func(t *testing.T) {
 			res, err := tc.fn()
@@ -214,44 +218,7 @@ func TestClientSpecificMethodHardFailure(t *testing.T) {
 		WithHTTPClient(internalClient),
 	)
 
-	ctx := context.Background()
-
-	testCases := []struct {
-		method string
-		fn     func() (*http.Response, error)
-	}{
-		{
-			http.MethodGet,
-			func() (*http.Response, error) {
-				return c.Get(ctx, dummyURL, dummyHeader)
-			},
-		},
-		{
-			http.MethodPost,
-			func() (*http.Response, error) {
-				return c.Post(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		{
-			http.MethodPut,
-			func() (*http.Response, error) {
-				return c.Put(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		{
-			http.MethodPatch,
-			func() (*http.Response, error) {
-				return c.Patch(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		{
-			http.MethodDelete,
-			func() (*http.Response, error) {
-				return c.Delete(ctx, dummyURL, dummyHeader)
-			},
-		},
-	}
-	for _, tc := range testCases {
+	for _, tc := range allMethodsTestCases(context.Background(), c) { // nolint
 		tc := tc
 		t.Run(tc.method, func(t *testing.T) {
 			res, err := tc.fn() // nolint
@@ -292,7 +259,7 @@ func TestClientDoStatusFailure(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
 }
 
-func TestClientSpecificMethodStatusFailure(t *testing.T) { // nolint
+func TestClientSpecificMethodStatusFailure(t *testing.T) {
 	hardFailures := 0
 	beforeStatusOK := 3
 	internalClient := newMockHTTPClient(t, hardFailures, beforeStatusOK)
@@ -309,44 +276,7 @@ func TestClientSpecificMethodStatusFailure(t *testing.T) { // nolint
 		}),
 	)
 
-	ctx := context.Background()
-
-	testCases := []struct {
-		method string
-		fn     func() (*http.Response, error)
-	}{
-		{
-			http.MethodGet,
-			func() (*http.Response, error) {
-				return c.Get(ctx, dummyURL, dummyHeader)
-			},
-		},
-		{
-			http.MethodPost,
-			func() (*http.Response, error) {
-				return c.Post(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		{
-			http.MethodPut,
-			func() (*http.Response, error) {
-				return c.Put(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		{
-			http.MethodPatch,
-			func() (*http.Response, error) {
-				return c.Patch(ctx, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader)
-			},
-		},
-		{
-			http.MethodDelete,
-			func() (*http.Response, error) {
-				return c.Delete(ctx, dummyURL, dummyHeader)
-			},
-		},
-	}
-	for _, tc := range testCases {
+	for _, tc := range allMethodsTestCases(context.Background(), c) { // nolint
 		tc := tc
 		t.Run(tc.method, func(t *testing.T) {
 			res, err := tc.fn()
@@ -363,42 +293,7 @@ func TestClientSpecificMethodStatusFailure(t *testing.T) { // nolint
 func TestClientSpecificMethodBadContext(t *testing.T) {
 	c := NewClient()
 
-	testCases := []struct {
-		method string
-		fn     func() (*http.Response, error)
-	}{
-		{
-			http.MethodGet,
-			func() (*http.Response, error) {
-				return c.Get(nil, dummyURL, dummyHeader) // nolint
-			},
-		},
-		{
-			http.MethodPost,
-			func() (*http.Response, error) {
-				return c.Post(nil, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader) // nolint
-			},
-		},
-		{
-			http.MethodPut,
-			func() (*http.Response, error) {
-				return c.Put(nil, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader) // nolint
-			},
-		},
-		{
-			http.MethodPatch,
-			func() (*http.Response, error) {
-				return c.Patch(nil, dummyURL, ioutil.NopCloser(strings.NewReader(dummyRequestBody)), dummyHeader) // nolint
-			},
-		},
-		{
-			http.MethodDelete,
-			func() (*http.Response, error) {
-				return c.Delete(nil, dummyURL, dummyHeader) // nolint
-			},
-		},
-	}
-	for _, tc := range testCases {
+	for _, tc := range allMethodsTestCases(nil, c) { // nolint
 		tc := tc
 		t.Run(tc.method, func(t *testing.T) {
 			res, err := tc.fn() // nolint

--- a/errors_test.go
+++ b/errors_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRequestCreationError(t *testing.T) {
 	err := RequestCreationError{
-		errors.New("an error message"), // nolint
+		errors.New("an error message"),
 	}
 	assert.Equal(t, "request creation failed: an error message", err.Error())
 }


### PR DESCRIPTION
Whenever the request body is non-empty, the retry would not work because the body was consumed at the first try, leading to failures for all the remaining attempts.

I also tried to reorganize the tests to make them slightly clearer.