### PR TITLE
ci: test and lint against Go 1.18

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -9,6 +9,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.38
+          version: v1.45

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x, 1.18.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,10 @@
+run:
+  go: 1.18
+
 linters:
   enable-all: true
   disable:
     - exhaustivestruct
-    - nlreturn
     - wrapcheck
     - wsl
 

--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		// Overwrite the request body using a NopCloser
 		req.Body = newNopCloserFromBody(body)
 
-		res, err = c.client.Do(req) // nolint
+		res, err = c.client.Do(req)
 		if err != nil {
 			return err
 		}
@@ -64,6 +64,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	if err != nil && !errors.Is(err, ErrStatusCode) {
 		return nil, err
 	}
+
 	return res, nil
 }
 
@@ -73,6 +74,7 @@ func copyHTTPRequestBody(req *http.Request) ([]byte, error) {
 	if req.Body == nil {
 		return nil, nil
 	}
+
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
@@ -80,6 +82,7 @@ func copyHTTPRequestBody(req *http.Request) ([]byte, error) {
 	if err := req.Body.Close(); err != nil {
 		return nil, err
 	}
+
 	return body, nil
 }
 
@@ -89,6 +92,7 @@ func newNopCloserFromBody(body []byte) io.ReadCloser {
 	if body == nil {
 		return nil
 	}
+
 	return io.NopCloser(bytes.NewReader(body))
 }
 
@@ -99,7 +103,8 @@ func (c *Client) Get(ctx context.Context, url string, headers http.Header) (*htt
 		return nil, &RequestCreationError{err}
 	}
 	req.Header = headers
-	return c.Do(req)
+
+	return c.Do(req.WithContext(ctx))
 }
 
 // Post makes a HTTP POST request to provided URL.
@@ -109,7 +114,8 @@ func (c *Client) Post(ctx context.Context, url string, body io.Reader, headers h
 		return nil, &RequestCreationError{err}
 	}
 	req.Header = headers
-	return c.Do(req)
+
+	return c.Do(req.WithContext(ctx))
 }
 
 // Put makes a HTTP PUT request to provided URL.
@@ -119,7 +125,8 @@ func (c *Client) Put(ctx context.Context, url string, body io.Reader, headers ht
 		return nil, &RequestCreationError{err}
 	}
 	req.Header = headers
-	return c.Do(req)
+
+	return c.Do(req.WithContext(ctx))
 }
 
 // Patch makes a HTTP PATCH request to provided URL.
@@ -129,6 +136,7 @@ func (c *Client) Patch(ctx context.Context, url string, body io.Reader, headers 
 		return nil, &RequestCreationError{err}
 	}
 	req.Header = headers
+
 	return c.Do(req)
 }
 
@@ -139,6 +147,7 @@ func (c *Client) Delete(ctx context.Context, url string, headers http.Header) (*
 		return nil, &RequestCreationError{err}
 	}
 	req.Header = headers
+
 	return c.Do(req)
 }
 
@@ -178,6 +187,7 @@ func NewClient(opts ...Option) *Client {
 	for _, opt := range opts {
 		opt(&client)
 	}
+
 	return &client
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/vthiery/avoca
 
-go 1.16
+go 1.18
+
+require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.7.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
See https://github.com/golangci/golangci-lint/issues/2649 for disabled linters that will hopefully get back in the future.