### PR TITLE
ci: run on go 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
-        platform: [ubuntu-latest, macos-latest]
+        go-version: [1.17.x, 1.18.x, 1.19.x]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go


### PR DESCRIPTION
Also removing MacOS pipeline which takes too much time and is unnecessary.